### PR TITLE
 Can't set the default value with block syntax in Rails 5

### DIFF
--- a/lib/configurable_exceptions.rb
+++ b/lib/configurable_exceptions.rb
@@ -4,8 +4,7 @@ require 'configurable_exceptions/rails' if defined? Rails::Railtie
 
 module ConfigurableExceptions
   class << self
-    cattr_accessor :show_exceptions do
-      false
-    end
+    cattr_accessor :show_exceptions
+    self.show_exceptions = false
   end
 end


### PR DESCRIPTION
After Rails 5, the block syntax of `cattr_accessor` won't be evaluated hence the current way of setting the default value is not working as expected (default will be `nil`)

And now Rails will treat a `nil` "action_dispatch.show_exceptions" as `true` to decide whether to  show_exceptions, that leads to unexpected behavior for the gem.

- Related mattr_accessor change: https://github.com/rails/rails/pull/21158
- Related `action_dispatch.show_exceptions` check: https://github.com/rails/rails/blob/afbbcf24d791362a65c7f29b739c73a5b09e3816/actionpack/lib/action_dispatch/http/request.rb#L166-L171