### PR TITLE
Convert middleware to Class instead Module

### DIFF
--- a/lib/configurable_exceptions.rb
+++ b/lib/configurable_exceptions.rb
@@ -2,9 +2,7 @@ require 'configurable_exceptions/version'
 require 'configurable_exceptions/middleware'
 require 'configurable_exceptions/rails' if defined? Rails::Railtie
 
-module ConfigurableExceptions
-  class << self
-    cattr_accessor :show_exceptions
-    self.show_exceptions = false
-  end
+class ConfigurableExceptions
+  cattr_accessor :show_exceptions
+  @@show_exceptions = false
 end

--- a/lib/configurable_exceptions/rails.rb
+++ b/lib/configurable_exceptions/rails.rb
@@ -1,4 +1,4 @@
-module ConfigurableExceptions
+class ConfigurableExceptions
   class Railtie < Rails::Railtie
     initializer "configurable_exceptions.configure_rails_initialization" do
       Rails.application.middleware.insert_before ActionDispatch::ShowExceptions, ConfigurableExceptions::Middleware

--- a/lib/configurable_exceptions/version.rb
+++ b/lib/configurable_exceptions/version.rb
@@ -1,3 +1,3 @@
-module ConfigurableExceptions
+class ConfigurableExceptions
   VERSION = "1.0.1"
 end


### PR DESCRIPTION
Original gem with Rails 6.1 broke with:
```
~/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/gems/activesupport-6.1.3.2/lib/active_support/core_ext/module/attribute_accessors.rb:52:in `mattr_reader': module attributes should be defined directly on class, not singleton (TypeError)
	from /Users/asor/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/gems/activesupport-6.1.3.2/lib/active_support/core_ext/module/attribute_accessors.rb:202:in `mattr_accessor'
	from /Users/asor/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/gems/configurable_exceptions-1.0.1/lib/configurable_exceptions.rb:7:in `singleton class'
	from /Users/asor/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/gems/configurable_exceptions-1.0.1/lib/configurable_exceptions.rb:6:in `<module:ConfigurableExceptions>'
...
```	